### PR TITLE
add ability to send addedBy in order to show all added patients

### DIFF
--- a/components/atoms/Stepper/Forms/identity2.js
+++ b/components/atoms/Stepper/Forms/identity2.js
@@ -96,7 +96,7 @@ function Identity2() {
 
     !values.email ? delete values.email : null;
 
-    const data = { ...formData, ...values };
+    const data = { ...formData, ...values, addedBy: session.user.data.userId };
 
     if (patientExist) {
       dispatch(


### PR DESCRIPTION
**Fixed issue when adding a patient but not completing a transaction. ( Bug 10.03 .4 )

A "addedBy" column is saved in the patient table pointing to the payerId, so it can be shown also in the list of patients added**